### PR TITLE
プロトタイプ一覧機能の表示

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -2,7 +2,7 @@ class PrototypesController < ApplicationController
   before_action :move_to_signin, except: [:create, :index]
 
   def index
-
+    @prototypes = Prototype.all
   end
 
   def new

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,0 +1,12 @@
+<div class="card">
+  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+  <div class="card__body">
+    <%= link_to prototype.title, root_path, class: :card__title%>
+    <p class="card__summary">
+      <%= prototype.catch_copy %>
+    </p>
+    <%= link_to "by #{prototype.title}", root_path, class: :card__user %>
+  </div>
+  
+
+</div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -11,6 +11,7 @@
        </div> 
     <%# // ログインしているときは上記を表示する %>
     <div class="card__wrapper">
+      <%= render partial: 'prototype', collection: @prototypes %>
       <%# 投稿機能実装後、部分テンプレートでプロトタイプ投稿一覧を表示する %>
     </div>
   </div>


### PR DESCRIPTION
＃ What
プロトタイプ一覧表示機能の作成
＃ Why
テーブルに保存されているプロトタイプがトップページに実装されているか確認するため

https://github.com/yuta-chi/protospace-162-wimbledon/assets/152576167/466a495a-7629-4f59-8eed-c925e5d59882

