### PR TITLE
プロトタイプ詳細機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_signin, except: [:create, :index]
+  before_action :move_to_signin, except: [:create, :index, :show]
 
   def index
     @prototypes = Prototype.all
@@ -16,6 +16,11 @@ class PrototypesController < ApplicationController
     else
       render 'new', status: :unprocessable_entity
     end
+  end
+
+  def show
+    prototype_id = params[:id]
+    @prototype = Prototype.find(prototype_id)
   end
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -19,8 +19,7 @@ class PrototypesController < ApplicationController
   end
 
   def show
-    prototype_id = params[:id]
-    @prototype = Prototype.find(prototype_id)
+    @prototype = Prototype.find(params[:id])
   end
 
   private

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,11 +1,11 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype)%>
   <div class="card__body">
-    <%= link_to prototype.title, root_path, class: :card__title%>
+    <%= link_to prototype.title, prototype_path(prototype), class: :card__title%>
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by #{prototype.title}", root_path, class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
   </div>
   
 

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -1,0 +1,56 @@
+<main class="main">
+  <div class="inner">
+    <div class="prototype__wrapper">
+      <p class="prototype__hedding">
+        <%= @prototype.title%>
+      </p>
+      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
+      <% if user_signed_in? && current_user.id == @prototype.user_id %>
+        <div class="prototype__manage">
+          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", root_path, class: :prototype__btn %>
+        </div>
+      <% end %>
+      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      <div class="prototype__image">
+        <%= image_tag @prototype.image %>
+      </div>
+      <div class="prototype__body">
+        <div class="prototype__detail">
+          <p class="detail__title">キャッチコピー</p>
+          <p class="detail__message">
+            <%= @prototype.catch_copy %>
+          </p>
+        </div>
+        <div class="prototype__detail">
+          <p class="detail__title">コンセプト</p>
+          <p class="detail__message">
+            <%= @prototype.concept %>
+          </p>
+        </div>
+      </div>
+      <div class="prototype__comments">
+        <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
+          <%# <%= form_with model: モデル名,local: true do |f|%>
+            <div class="field">
+              <%# <%= f.label :hoge, "コメント" %><br />
+              <%# <%= f.text_field :hoge, id:"comment_content" %>
+            </div>
+            <div class="actions">
+              <%# <%= f.submit "送信する", class: :form__btn  %>
+            </div>
+          <%# <% end %>
+        <%# // ログインしているユーザーには上記を表示する %>
+        <ul class="comments_lists">
+          <%# 投稿に紐づくコメントを一覧する処理を記述する %>
+            <li class="comments_list">
+              <%# <%= " コメントのテキスト "%>
+              <%# <%= link_to "（ ユーザー名 ）", root_path, class: :comment_user %>
+            </li>
+          <%# // 投稿に紐づくコメントを一覧する処理を記述する %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "prototypes#index"
-  resources :prototypes, only: [:new, :create, :index]
+  resources :prototypes, only: [:new, :create, :index, :show]
 end


### PR DESCRIPTION
# What
プロトタイプ詳細機能
# Why
・トップページからプロトタイプの詳細ページが表示され、必要な情報がすべて表示されているように実装するため
・プロトタイプ情報の「編集」「削除」のボタンは、そのプロトタイプ情報を投稿した人以外には表示されないようにするため

